### PR TITLE
Double requirements given

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,4 @@ icmplib>=2.0.2
 netifaces>=0.10.4
 PyYAML>=5.4.1
 pysqlite3>=0.4.5
-icmplib
 timeago
-flask_mqtt


### PR DESCRIPTION
Double requirement given: icmplib (from -r requirements.txt (line 9)) (already in icmplib>=2.0.2 (from -r requirements.txt (line 5)), name='icmplib')
Double requirement given: flask_mqtt (from -r requirements.txt (line 10)) (already in Flask-MQTT>=1.1.1 (from -r requirements.txt (line 3)), name='flask-mqtt')